### PR TITLE
Nat instance: allow to upload bigger images

### DIFF
--- a/prd/ansible-nat-instance/mastodon.conf
+++ b/prd/ansible-nat-instance/mastodon.conf
@@ -15,6 +15,9 @@ server {
   include /etc/letsencrypt/options-ssl-nginx.conf; # managed by Certbot
   ssl_dhparam /etc/letsencrypt/ssl-dhparams.pem; # managed by Certbot
 
+  keepalive_timeout    70;
+  client_max_body_size 80m;
+
   location / {
     proxy_pass http://10.0.3.178:80;
     proxy_set_header Host $host;


### PR DESCRIPTION
Getting /api/v2/media HTTP/1.1" 413 183 "-" when uploading large images ...