### PR TITLE
chore: fix warning

### DIFF
--- a/prd/eip.tf
+++ b/prd/eip.tf
@@ -1,3 +1,3 @@
 resource "aws_eip" "mastodon-public-eip" {
-  vpc = true
+  domain = "vpc"
 }


### PR DESCRIPTION
Fixes:
  with aws_eip.mastodon-public-eip,
│   on eip.tf line 2, in resource "aws_eip" "mastodon-public-eip":
│    2:   vpc = true
│
│ use domain attribute instead